### PR TITLE
Bugfix + support for SQL parameters

### DIFF
--- a/R/cosmosQuery.R
+++ b/R/cosmosQuery.R
@@ -36,11 +36,7 @@ cosmosQuery <- function(sql.what = "*", sql.where = "", max.items = 100, debug.a
     full.query <- constructQuery(sql.what, sql.where)
 
     # Convert full query to JSON for HTTP POST
-    json.query <- toJSON(list(query = full.query, parameters = list()))
-
-    # First set of brackets break the operation; remove them
-    json.query <- str_replace(json.query, fixed("["), "")
-    json.query <- str_replace(json.query, fixed("]"), "")
+    json.query <- toJSON(list(query = unbox(full.query), parameters = list()))
 
     # Generate auth header using specifications
     auth.header <- genHeader(verb = "POST", resource.type = res.type, resource.link = res.link, stored.time = ms.date.string, debug = debug.auth)

--- a/R/cosmosQuery.R
+++ b/R/cosmosQuery.R
@@ -12,7 +12,7 @@
 #' cosmosQuery(sql.what = "c.contact.eloquaId", sql.where = "c.contact.eloquaId != null")
 
 cosmosQuery <- function(sql.what = "*", sql.where = "", sql.params = list(), max.items = 100, debug.auth = FALSE, debug.query = FALSE,
-                        content.response = FALSE) {
+                        content.response = FALSE, flatten = FALSE) {
 
     require(digest)
     require(base64enc)
@@ -67,7 +67,7 @@ cosmosQuery <- function(sql.what = "*", sql.where = "", sql.params = list(), max
         if (content.response == FALSE) {
             next_data_frame <- raw.response
         } else if (content.response == TRUE) {
-            char.response <- readContent(raw.response)
+            char.response <- readContent(raw.response, flatten = flatten)
             next_data_frame <- char.response$Documents
         }
 
@@ -78,6 +78,6 @@ cosmosQuery <- function(sql.what = "*", sql.where = "", sql.params = list(), max
         # See https://docs.microsoft.com/en-us/rest/api/cosmos-db/querying-cosmosdb-resources-using-the-rest-api#pagination-of-query-results
         if (is.null(raw.response$headers[["x-ms-continuation"]])) { break }
     }
-
+    
     return(rbind_pages(all_data_frames))
 }

--- a/R/cosmosQuery.R
+++ b/R/cosmosQuery.R
@@ -11,7 +11,8 @@
 #' @examples
 #' cosmosQuery(sql.what = "c.contact.eloquaId", sql.where = "c.contact.eloquaId != null")
 
-cosmosQuery <- function(sql.what = "*", sql.where = "", max.items = 100, debug.auth = FALSE, debug.query = FALSE, content.response = FALSE) {
+cosmosQuery <- function(sql.what = "*", sql.where = "", sql.params = list(), max.items = 100, debug.auth = FALSE, debug.query = FALSE,
+                        content.response = FALSE) {
 
     require(digest)
     require(base64enc)
@@ -36,7 +37,7 @@ cosmosQuery <- function(sql.what = "*", sql.where = "", max.items = 100, debug.a
     full.query <- constructQuery(sql.what, sql.where)
 
     # Convert full query to JSON for HTTP POST
-    json.query <- toJSON(list(query = unbox(full.query), parameters = list()))
+    json.query <- toJSON(list(query = full.query, parameters = sql.params), auto_unbox = T)
 
     # Generate auth header using specifications
     auth.header <- genHeader(verb = "POST", resource.type = res.type, resource.link = res.link, stored.time = ms.date.string, debug = debug.auth)

--- a/R/readContent.R
+++ b/R/readContent.R
@@ -7,13 +7,13 @@
 #' @examples
 #' readContent(http.response)
 
-readContent <- function(binary.stream) {
+readContent <- function(binary.stream, flatten = FALSE) {
 
     # Parse binary response into character
     char.response <- readBin(binary.stream$content, "character")
 
     # Convert the character response to json
-    json.response <- fromJSON(char.response)
+    json.response <- fromJSON(char.response, flatten = flatten)
 
     # Return the json
     json.response


### PR DESCRIPTION
This PR contains two distinct changes:

1) Fixed a bug where queries that used bracket syntax were broken (e.g. `SELECT * from c where c['$someField'] = 1`). This bracket notation is necessary for querying against fields with special characters like $.

2) Added support for SQL parameters with an optional `sql.params` argument. If used, this should be a list of lists like:

```
sql.params = list(list("name" = "@height", "value" = 5), list("name" = "@width", "value" = 300))
```
which becomes a JSON object like:

```
[ { name: "@height", value: 5 }, { name: "@width", value: 300 } ]
```